### PR TITLE
Fix mismatched field names in schemas

### DIFF
--- a/app/schemas/material.py
+++ b/app/schemas/material.py
@@ -5,7 +5,7 @@ from typing import Optional
 class MaterialBase(BaseModel):
     name: str
     unit: Optional[str] = None
-    archived: bool = False
+    is_archived: bool = False
 
 
 class MaterialCreate(MaterialBase):
@@ -15,7 +15,7 @@ class MaterialCreate(MaterialBase):
 class MaterialUpdate(MaterialBase):
     name: Optional[str] = None
     unit: Optional[str] = None
-    archived: Optional[bool] = None
+    is_archived: Optional[bool] = None
 
 
 class Material(MaterialBase):

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -7,7 +7,7 @@ from .tool_transfer import ToolTransfer, ToolTransferCreate, ToolTransferUpdate
 class SiteBase(BaseModel):
     name: str
     address: Optional[str] = None
-    archived: bool = False
+    is_archived: bool = False
     subgroup_id: Optional[int] = None
 
 class SiteCreate(SiteBase):

--- a/app/schemas/site.py
+++ b/app/schemas/site.py
@@ -13,12 +13,12 @@ class SiteCreate(SiteBase):
 
 
 class SiteUpdate(SiteBase):
-    archived: Optional[bool] = None
+    is_archived: Optional[bool] = None
 
 
 class Site(SiteBase):
     id: int
-    archived: bool
+    is_archived: bool
 
     class Config:
         from_attributes = True  # Используем from_attributes для совместимости с Pydantic V2


### PR DESCRIPTION
## Summary
- align `Site` and `Material` schemas with SQLAlchemy models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842c0db295083328fc9698d6076815d